### PR TITLE
feat(serial): stable merge + sequential mergesort baseline

### DIFF
--- a/comp2002-os-mergesort/mergesort.c
+++ b/comp2002-os-mergesort/mergesort.c
@@ -8,20 +8,59 @@
 #include "mergesort.h"
 
 /* this function will be called by mergesort() and also by parallel_mergesort(). */
-void merge(int leftstart, int leftend, int rightstart, int rightend){
+void merge(int leftstart, int leftend, int rightstart, int rightend) {
+    // Preconditions (by construction from mergesort):
+    // leftstart <= leftend < rightstart <= rightend
+    // We’ll merge the two sorted halves into A[leftstart..rightend].
+
+    int L = leftstart;
+    int R = rightend;
+
+    // 1) Copy the whole span once from A -> B
+    size_t bytes = (size_t)(R - L + 1) * sizeof(int);
+    memcpy(&B[L], &A[L], bytes);
+
+    // 2) Merge from B back into A
+    int i = leftstart;   // scans left half in B
+    int j = rightstart;  // scans right half in B
+    int k = leftstart;   // scans A where we write next
+
+    while (i <= leftend && j <= rightend) {
+        if (B[i] <= B[j]) A[k++] = B[i++];
+        else              A[k++] = B[j++];
+    }
+    // Copy any remainder from the side that’s not finished
+    while (i <= leftend)  A[k++] = B[i++];
+    while (j <= rightend) A[k++] = B[j++];
 }
 
 /* this function will be called by parallel_mergesort() as its base case. */
-void my_mergesort(int left, int right){
+void my_mergesort(int left, int right) {
+    if (left >= right) return;  // 0 or 1 element: already sorted
+
+    int mid = left + (right - left) / 2;
+
+    // Sort left half and right half
+    my_mergesort(left, mid);
+    my_mergesort(mid + 1, right);
+
+    // Merge the two sorted halves
+    merge(left, mid, mid + 1, right);
 }
 
+
 /* this function will be called by the testing program. */
-void * parallel_mergesort(void *arg){
-		return NULL;
+void *parallel_mergesort(void *arg) {
+    struct argument *a = (struct argument *)arg;
+    my_mergesort(a->left, a->right);   // serial baseline
+    return NULL;                       // tester frees the root arg
 }
 
 /* we build the argument for the parallel_mergesort function. */
-struct argument * buildArgs(int left, int right, int level){
-		return NULL;
+struct argument *buildArgs(int left, int right, int level) {
+    struct argument *p = malloc(sizeof *p);
+    if (!p) { perror("malloc"); exit(1); }
+    p->left = left; p->right = right; p->level = level;
+    return p;
 }
 

--- a/comp2002-os-mergesort/test-mergesort.c
+++ b/comp2002-os-mergesort/test-mergesort.c
@@ -4,7 +4,6 @@
 #include <sys/times.h> /* for times system call */
 #include <sys/time.h>  /* for gettimeofday system call */
 #include <unistd.h>
-#include <error.h>     /* On MacOS you won't need this line */
 #include "mergesort.h"
 
 /* the number of levels of threads, specified by the user */

--- a/cs3004-os-mergesort/mergesort.c
+++ b/cs3004-os-mergesort/mergesort.c
@@ -1,0 +1,66 @@
+/**
+ * This file implements parallel mergesort.
+ */
+
+#include <stdio.h>
+#include <string.h> /* for memcpy */
+#include <stdlib.h> /* for malloc */
+#include "mergesort.h"
+
+/* this function will be called by mergesort() and also by parallel_mergesort(). */
+void merge(int leftstart, int leftend, int rightstart, int rightend) {
+    // Preconditions (by construction from mergesort):
+    // leftstart <= leftend < rightstart <= rightend
+    // We’ll merge the two sorted halves into A[leftstart..rightend].
+
+    int L = leftstart;
+    int R = rightend;
+
+    // 1) Copy the whole span once from A -> B
+    size_t bytes = (size_t)(R - L + 1) * sizeof(int);
+    memcpy(&B[L], &A[L], bytes);
+
+    // 2) Merge from B back into A
+    int i = leftstart;   // scans left half in B
+    int j = rightstart;  // scans right half in B
+    int k = leftstart;   // scans A where we write next
+
+    while (i <= leftend && j <= rightend) {
+        if (B[i] <= B[j]) A[k++] = B[i++];
+        else              A[k++] = B[j++];
+    }
+    // Copy any remainder from the side that’s not finished
+    while (i <= leftend)  A[k++] = B[i++];
+    while (j <= rightend) A[k++] = B[j++];
+}
+
+/* this function will be called by parallel_mergesort() as its base case. */
+void my_mergesort(int left, int right) {
+    if (left >= right) return;  // 0 or 1 element: already sorted
+
+    int mid = left + (right - left) / 2;
+
+    // Sort left half and right half
+    my_mergesort(left, mid);
+    my_mergesort(mid + 1, right);
+
+    // Merge the two sorted halves
+    merge(left, mid, mid + 1, right);
+}
+
+
+/* this function will be called by the testing program. */
+void *parallel_mergesort(void *arg) {
+    struct argument *a = (struct argument *)arg;
+    my_mergesort(a->left, a->right);   // serial baseline
+    return NULL;                       // tester frees the root arg
+}
+
+/* we build the argument for the parallel_mergesort function. */
+struct argument *buildArgs(int left, int right, int level) {
+    struct argument *p = malloc(sizeof *p);
+    if (!p) { perror("malloc"); exit(1); }
+    p->left = left; p->right = right; p->level = level;
+    return p;
+}
+


### PR DESCRIPTION
what I did:
* Implemented `merge()`:
  - Copy A[left..right] → B[left..right] once, then stable two-pointer merge from B→A.
  - Inclusive indices; right half starts at mid+1. Left wins ties (stable).
- Implemented `my_mergesort()` (recurse left/right, then merge).
- Minimal `buildArgs()` and temporary `parallel_mergesort()` that routes to the serial sorter so cutoff=0 works.

In doing it will help us develope a baseline for later speedup comparisons. read from snapshot B, write into A → we never overwrite data we still need.

Trouble
-Tester always calls parallel_mergesort (even with cutoff=0); stub did nothing → “sorting failed!!!!”, Now parallel_mergesort calls my_mergesort(a->left, a->right) so serial path sorts correctly. 
-lpthread` warning on macOS → built locally with `-pthread`  

Testiing 
<img width="936" height="264" alt="Screenshot 2025-10-23 at 4 49 44 pm" src="https://github.com/user-attachments/assets/d99bc648-ea5e-42b9-82b2-24962d290df6" />

- `./test-mergesort 1000 0 42` → OK
- `./test-mergesort 1000000 0 42` → OK (prints times) 

Tool: GPT was used to helped me understand why the harness printed “sorting failed!!!!” (root cause: parallel_mergesort stub). 