### PR TITLE
Some tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,8 @@ dkms.conf
 # debug information files
 *.dwo
 
-# LSP files
+# Project-specific
+
 compile_flags.txt
+*.test
+test-mergesort

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # surely gradescope machines have a compiler which can do post Y2K C ....
 
 CC		= cc
-CFLAGS	= -Wall -Wpointer-arith -Wstrict-prototypes -std=c11 -fPIC
+CFLAGS	= -Wall -Wpointer-arith -Wstrict-prototypes -std=gnu89 -fPIC
 
 # Pathname of the pkg-config compatible utility
 # (not using this for this assignment at all)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # surely gradescope machines have a compiler which can do post Y2K C ....
 
 CC		= cc
-CFLAGS	= -Wall -Wpointer-arith -Wstrict-prototypes -std=gnu89 -fPIC
+CFLAGS	= -Wall -Wpointer-arith -Wstrict-prototypes -std=gnu11 -fPIC
 
 # Pathname of the pkg-config compatible utility
 # (not using this for this assignment at all)
@@ -28,7 +28,7 @@ all: $(BIN)
 $(BIN): $(OBJ)
 	$(CC) $(CFLAGS) -o $@ $(OBJ) $(LDFLAGS)
 
-# Suffix rules to create .o and .d files from sources
+# Implicit suffix rules to create .o and .d files from sources
 .SUFFIXES: .c .o
 .c.o:
 	$(CC) $(CFLAGS) $(INC) -c $<
@@ -37,10 +37,23 @@ $(BIN): $(OBJ)
 .c.d:
 	$(CC) -MM $< -o $@
 
-# Unit tests
-test: mergesort.o merge_test.o buildargs_test.o
-	$(CC) $(CFLAGS) -o merge.test merge_test.o mergesort.o
-	$(CC) $(CFLAGS) -o buildargs.test buildargs_test.o mergesort.o
+# Unit tests -- lets anticipate all the unit tests
+tests: mergesort.o merge.o buildargs.o my_mergesort.o parallel_mergesort.o
+
+	$(CC) $(CFLAGS) -o merge.test 				merge.o mergesort.o
+	$(CC) $(CFLAGS) -o buildargs.test 			buildargs.o mergesort.o
+	$(CC) $(CFLAGS) -o my_mergesort.test 		my_mergesort.o mergesort.o
+	$(CC) $(CFLAGS) -o parallel_mergesort.test	parallel_mergesort.o mergesort.o
+
+# Explicit test source recipes
+merge.o: tests/merge.c
+	$(CC) $(CFLAGS) -c $< -o merge.o
+buildargs.o: tests/buildargs.c
+	$(CC) $(CFLAGS) -c $< -o buildargs.o
+my_mergesort.o: tests/my_mergesort.c
+	$(CC) $(CFLAGS) -c $< -o my_mergesort.o
+parallel_mergesort.o: tests/parallel_mergesort.c
+	$(CC) $(CFLAGS) -c $< -o parallel_mergesort.o
 
 # Generate LSP database on each clean
 db:

--- a/tests/buildargs.c
+++ b/tests/buildargs.c
@@ -2,11 +2,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "mergesort.h"
+#include "../mergesort.h"
 
+/* global state is safe and good and never goes wrong and doesn't make testing difficult! */
+/* declare the god-damned externals! (SO STUPID!!!!!) */
 int* A;
 int* B;
-
 int cutoff;
 
 int main(void) {

--- a/tests/merge.c
+++ b/tests/merge.c
@@ -2,12 +2,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "mergesort.h"
+#include "../mergesort.h"
 
-// global state is safe and good and never goes wrong and doesn't make testing difficult!
+/* global state is safe and good and never goes wrong and doesn't make testing difficult! */
+/* declare the god-damned externals! (SO STUPID!!!!!) */
 int* A;
 int* B;
-
 int cutoff;
 
 void printA(size_t start, size_t end) {

--- a/tests/my_mergesort.c
+++ b/tests/my_mergesort.c
@@ -1,0 +1,10 @@
+#include "../mergesort.h"
+/* global state is safe and good and never goes wrong and doesn't make testing difficult! */
+/* declare the god-damned externals! (SO STUPID!!!!!) */
+int* A;
+int* B;
+int cutoff;
+
+int main(void) {
+	return 0;
+}

--- a/tests/parallel_mergesort.c
+++ b/tests/parallel_mergesort.c
@@ -1,0 +1,10 @@
+#include "../mergesort.h"
+/* global state is safe and good and never goes wrong and doesn't make testing difficult! */
+/* declare the god-damned externals! (SO STUPID!!!!!) */
+int* A;
+int* B;
+int cutoff;
+
+int main(void) {
+	return 0;
+}


### PR DESCRIPTION
Fix compile issue related to `c11` standard instead of `gnu89`. Changes the C standard to be `gnu89` since driving code in `test-mergesort.c` references a function `random()` which must be a GNU extension. Also adds the binaries `test-mergesort` and all the unit tests `*.test` to `.gitignore`